### PR TITLE
Add article.readtime_minutes attribute, int only, less verbose

### DIFF
--- a/readtime.py
+++ b/readtime.py
@@ -29,6 +29,7 @@ def read_time(content):
         minutes_str = pluralize(minutes, "Minute", "Minutes")
         seconds_str = pluralize(seconds, "Second", "Seconds")
         content.readtime = "{} and {}".format(minutes_str, seconds_str)
+        content.readtime_minutes = minutes + int(bool(seconds))
 
 
 def pluralize(measure, singular, plural):


### PR DESCRIPTION
I wanted to add "readtime" similar to the one on medium. The fully formated readtime that this plugin provide is too verbose. The number of minutes, as an int, is enough for most needs.
