### PR TITLE
Fix warning in Pelican 3.6 and above related to content

### DIFF
--- a/readtime.py
+++ b/readtime.py
@@ -23,7 +23,7 @@ def read_time(content):
         # We get the content's text, split it at the spaces and check the
         # length of the provided array to get a good estimation on the amount
         # of words in the content.
-        words = len(content.content.split())
+        words = len(content._content.split())
         read_time_seconds = round((words / AVERAGE_READING_WPM) * 60, 2)
         minutes, seconds = get_time_from_seconds(read_time_seconds)
         minutes_str = pluralize(minutes, "Minute", "Minutes")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as readme_file:
 
 setup(
     name='pelican-readtime',
-    version='0.1.2',
+    version='0.1.3',
     description='Plugin for Pelican that computes read time based on Medium\'s readtime "algorithm."',
     long_description=readme,
     url='https://github.com/JenkinsDev/pelican-readtime',


### PR DESCRIPTION
In Pelican 3.6 and above a warning will be trigger when linking to external content. Pelican documentation recommends to use the property _content instead of content.